### PR TITLE
EX-1284: Delete meta variable docs

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -9,3 +9,4 @@ Our API is available to any of our organizations' users at `{orgname}.ada.suppor
 #### [Errors](errors.md)
 ### Resources
 #### [Messages](messages.md)
+#### [Meta Variables](metavariables.md)

--- a/api/index.md
+++ b/api/index.md
@@ -9,4 +9,4 @@ Our API is available to any of our organizations' users at `{orgname}.ada.suppor
 #### [Errors](errors.md)
 ### Resources
 #### [Messages](messages.md)
-#### [Meta Variables](metavariables.md)
+#### [Meta Variable Deletion](metavariables.md)

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -7,7 +7,7 @@
 ## Prerequisites
 This document is intended *for developers* with working knowledge of REST APIs and JavaScript. It is assumed that you have write-access to your company's code repository which contains **Ada Embed**.
 
-The following instructions will reference the usage of a **chatter token**. See the [Ada Embed docs](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#configuring-your-bot) for more information how to get a chatter's token using ```chatterTokenCallback```.
+The following instructions will reference the usage of a **chatter token**. See the [Ada Embed docs](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#configuring-your-bot) for more information on how to get a chatter's token using ```chatterTokenCallback```.
 
 ## PATCH `/chatters/<chatter-token>/remove_from_storage`
 You must have a chatter token to use this endpoint: `https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage`.

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -1,0 +1,67 @@
+# Meta Variable Deletion - Developer Docs
+
+> Meta Variables are automatically collected and specific to an individual chatter, as part of the implementation of your **Ada** bot. Any information passed from **your databse** to the bot as metadata will be stored by Ada as a Meta Variable of that chatter. However, Ada provides two API endpoints which you can use to ensure that given Meta Variable values are deleted from a given chatter.
+
+![ada animated gif](https://user-images.githubusercontent.com/4740147/47372740-5b5dca80-d6b8-11e8-87e7-1b76d48370d8.gif "Ada Animated Gif")
+
+## Table of Contents
+1. [Prerequisites](#prerequisites)
+2. [Deleting Meta Variable values in reaction to an event](#deleting-event-related)
+3. [Deleting Meta Variable values at a specific time](#deleting-time-related)
+4. [Questions](#questions)
+
+## Prerequisites
+This document is intended *for developers* with working knowledge of REST APIs and JavaScript. It is assumed that you have write-access to your company's code repository which contains **Ada Embed**.
+
+The following instructions will reference the usage of a **chatter token**. See the [Ada Embed docs](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#configuring-your-bot) for more information how to get back a chatter token using ```chatterTokenCallback```.
+
+## Deleting Meta Variable values in reaction to an event
+For security reasons, you might want to delete the values stored in a specific Meta Variable for a specific chatter, typically in reaction to an event such as a chatter being **properly closed.**
+
+As long as you have a **chatter token** on hand, you can delete the values for one or more Meta Variables stored by Ada for that chatter instance.
+
+##### Endpoint
+This is the PATCH endpoint used for deleting a chatter's Meta Variables:
+```https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage```
+
+##### Request body
+The body of the request looks like this:
+```
+{"variables":
+	["variable_1", "variable_2"]
+}
+```
+
+##### Passing Meta Variables
+The value of "variables" is an array that takes one or more Meta Variable names whose values you'd like to delete from Ada's storage.
+
+| NOTE: This deletion method is only effective in situations where a chatter is properly closed (ie. on logout). For situations where a chatter is improperly closed (ie. on browser crash, on tab-close, on window-close), please see [Deleting Meta Variable values at a specific time](#Deleting Meta Variable values at a specific time). |
+| --- |
+
+## Deleting Meta Variable values at a specific time
+When chatters are improperly closed (eg. on browser crash, on tab-close, on window-close), Meta Variable values cannot be immediately deleted. In such instances, the deletion task will fall to a background job run by Ada every 24 hours.
+
+Ada's variable-deletion backgroud job runs on a nightly basis, searching for all chatter instances with "expired" Meta Variables. A variable is considered expired if the date and time has already passed in relation to the date and time at which Ada's background job is run. The job will delete the values of these expired Meta Variables and remove the "expiry settings" from a given chatter.
+
+##### Endpoint
+For this task to run successfully, you will need to use the following PATCH endpoint to ensure that "variable_expiry_settings" are always set for all chatter instances:
+```https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry```
+
+##### Request body
+The body of the request looks like this:
+```
+{"variable_expiry_settings":
+	{
+		"expiry": "2011-10-05T14:48:00.000Z",
+		"meta_vars": ["variable_1", "variable_2"]
+	}
+}
+```
+##### Passing Meta Variables
+The value of "meta_vars" is an array that takes one or more Meta Variable names whose values you'd like to delete from Ada's storage.
+
+##### Passing an expiry date
+The value of "expiry" is an ISO 8601 formatted datetime (extended notation), with an optional timezone. See JavaScript's ```.toIsoString()``` method.
+
+## Questions
+Need some help? Get in touch with us at [help@ada.support](mailto:help@ada.support).

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -39,13 +39,13 @@ Ada's variable-deletion background job runs on a nightly basis, searching for al
 
 This endpoint therefore serves two purposes, as it must be used to:
 1. Set `variable_expiry_settings` on all chatters, which allows an **improperly closed** chatter to be picked up by Ada's nightly background task so that its expired Meta Variables can be deleted;
-1. Remove `variable_expiry_settings` from a given chatter whose Meta Variables are deleted using PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage`, so that the chatter isn't picked up by Ada's nightly background task.
+1. Remove `variable_expiry_settings` from a given chatter whose Meta Variables are deleted using PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage`, so that the chatter is **not** picked up by Ada's nightly background task.
 
 ### Expected Keys
 Parameter | Description | Optionality
 --- | --- | ---
 `variable_expiry_settings` | An object. Its value can be another object with keys `expiry` **AND** `meta_vars`. <br> Its value can also be `null`. | **required**
-`expiry` | An ISO 8601 formatted datetime (extended notation) | **optional**
+`expiry` | An ISO 8601 formatted datetime (extended notation) UTC timestamp | **optional**
 `meta_vars` | An array of Meta Variable names. | **optional**
 
 ### Example Request Body: Setting `variable_expiry_settings`

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -14,7 +14,7 @@ You must have a chatter token to use this endpoint: `https://<bothandle>.ada.sup
 
 This endpoint allows you to delete a chatter's Meta Variables. It must be used in reaction to an event, such as a chatter being **properly closed** (eg. on user logout).
 
-Meta Variable deletion for chatters that are **improperly closed** (eg. on tab-close, on window-close, on browser crash) is handled by PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry`. This end point must be used to set and remove Meta Variable expiry settings on all chatters (see docs below).
+Meta Variable deletion for chatters that are **improperly closed** (eg. on tab-close, on window-close, on browser crash) is handled by PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry`. This endpoint must be used to set and remove Meta Variable expiry settings on all chatters (see docs below).
 
 ### Expected Keys
 

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -20,7 +20,7 @@ Meta Variable deletion for chatters that are **improperly closed** (eg. on tab-c
 
 Parameter | Description | Optionality
 --- | --- | ---
-`variables` | An array. Takes one or more Meta Variable names. Will **not** throw an error if the array is empty. | **needed**
+`variables` | An array. Takes one or more Meta Variable names. Will **not** throw an error if the array is empty. | **required**
 ### Example Request Body
 ```
 {"variables":
@@ -44,16 +44,15 @@ This endpoint therefore serves two purposes, as it must be used to:
 ### Expected Keys
 Parameter | Description | Optionality
 --- | --- | ---
-`variable_expiry_settings` | An object. Its value can be another object with keys `expiry` **AND** `meta_vars`. <br> Its value can also be `null`. | **needed**
-`expiry` | An ISO 8601 formatted datetime (extended notation), with an optional timezone. | **optional**
+`variable_expiry_settings` | An object. Its value can be another object with keys `expiry` **AND** `meta_vars`. <br> Its value can also be `null`. | **required**
+`expiry` | An ISO 8601 formatted datetime (extended notation) | **optional**
 `meta_vars` | An array of Meta Variable names. | **optional**
-`null` | Passing `null` will remove `variable_expiry_settings` from  a chatter. | **optional**
 
 ### Example Request Body: Setting `variable_expiry_settings`
 ```
 {"variable_expiry_settings":
 	{
-		"expiry": "2011-10-05T14:48:00.000Z",
+		"expiry": "2011-10-05T14:48:00",
 		"meta_vars": ["variable_1", "variable_2"]
 	}
 }

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -45,7 +45,7 @@ This endpoint therefore serves two purposes, as it must be used to:
 Parameter | Description | Optionality
 --- | --- | ---
 `variable_expiry_settings` | An object. Its value can be another object with keys `expiry` **AND** `meta_vars`. <br> Its value can also be `null`. | **required**
-`expiry` | An ISO 8601 formatted datetime (extended notation) UTC timestamp | **optional**
+`expiry` | An ISO 8601 formatted datetime (extended notation) UTC timestamp. | **optional**
 `meta_vars` | An array of Meta Variable names. | **optional**
 
 ### Example Request Body: Setting `variable_expiry_settings`

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -4,12 +4,6 @@
 
 ![ada animated gif](https://user-images.githubusercontent.com/4740147/47372740-5b5dca80-d6b8-11e8-87e7-1b76d48370d8.gif "Ada Animated Gif")
 
-## Table of Contents
-1. [Prerequisites](#prerequisites)
-2. [Deleting Meta Variable values in reaction to an event](#deleting-event-related)
-3. [Deleting Meta Variable values at a specific time](#deleting-time-related)
-4. [Questions](#questions)
-
 ## Prerequisites
 This document is intended *for developers* with working knowledge of REST APIs and JavaScript. It is assumed that you have write-access to your company's code repository which contains **Ada Embed**.
 
@@ -19,33 +13,38 @@ The following instructions will reference the usage of a **chatter token**. See 
 For security reasons, you might want to delete the values stored in a specific Meta Variable for a specific chatter, typically in reaction to an event such as a chatter being **properly closed.**
 
 As long as you have a **chatter token** on hand, you can delete the values for one or more Meta Variables stored by Ada for that chatter instance.
+| NOTE: This deletion method is only effective in situations where a chatter is properly closed (ie. on logout). For situations where a chatter is improperly closed (ie. on browser crash, on tab-close, on window-close), please see "Deleting Meta Variable values at a specific time". |
+| --- |
 
-##### Endpoint
-This is the PATCH endpoint used for deleting a chatter's Meta Variables:
-```https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage```
-
-##### Request body
-The body of the request looks like this:
+##### PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage`
+#
+##### Expected Keys
+This request body of this endpoint expects the following:
+Parameter | Description | Optionality
+--- | --- | ---
+`variables` | An array that takes one or more Meta Variable names. | **needed**
+##### Example Request Body
+Here is an example of what you can pass to the endpoint:
 ```
 {"variables":
 	["variable_1", "variable_2"]
 }
 ```
 
-##### Passing Meta Variables
-The value of "variables" is an array that takes one or more Meta Variable names whose values you'd like to delete from Ada's storage.
-
-| NOTE: This deletion method is only effective in situations where a chatter is properly closed (ie. on logout). For situations where a chatter is improperly closed (ie. on browser crash, on tab-close, on window-close), please see [Deleting Meta Variable values at a specific time](#Deleting Meta Variable values at a specific time). |
-| --- |
-
 ## Deleting Meta Variable values at a specific time
 When chatters are improperly closed (eg. on browser crash, on tab-close, on window-close), Meta Variable values cannot be immediately deleted. In such instances, the deletion task will fall to a background job run by Ada every 24 hours.
 
 Ada's variable-deletion backgroud job runs on a nightly basis, searching for all chatter instances with "expired" Meta Variables. A variable is considered expired if the date and time has already passed in relation to the date and time at which Ada's background job is run. The job will delete the values of these expired Meta Variables and remove the "expiry settings" from a given chatter.
 
-##### Endpoint
-For this task to run successfully, you will need to use the following PATCH endpoint to ensure that "variable_expiry_settings" are always set for all chatter instances:
-```https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry```
+##### PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry`
+#
+##### Expected Keys
+This request body of this endpoint expects the following:
+Parameter | Description | Optionality
+--- | --- | ---
+`variable_expiry_settings` | An object that has two properties, `expiry` and `meta_vars`. | **needed**
+`expiry` | An ISO 8601 formatted datetime (extended notation), with an optional timezone. | **needed**
+`meta_vars` | An array of Meta Variable names. | **needed**
 
 ##### Request body
 The body of the request looks like this:
@@ -57,11 +56,7 @@ The body of the request looks like this:
 	}
 }
 ```
-##### Passing Meta Variables
-The value of "meta_vars" is an array that takes one or more Meta Variable names whose values you'd like to delete from Ada's storage.
 
-##### Passing an expiry date
-The value of "expiry" is an ISO 8601 formatted datetime (extended notation), with an optional timezone. See JavaScript's ```.toIsoString()``` method.
 
 ## Questions
 Need some help? Get in touch with us at [help@ada.support](mailto:help@ada.support).

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -14,13 +14,13 @@ You must have a chatter token to use this endpoint: `https://<bothandle>.ada.sup
 
 This endpoint allows you to delete a chatter's Meta Variables. It must be used in reaction to an event, such as a chatter being **properly closed** (eg. on user logout).
 
-Meta Variable deletion for chatters that are **improperly closed** (eg. on tab-close, on window-close, on browser crash) are handled by PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry`, which is used to set and remove Meta Variable expiry settings on all chatters (see docs below).
+Meta Variable deletion for chatters that are **improperly closed** (eg. on tab-close, on window-close, on browser crash) is handled by PATCH `https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry`. This end point must be used to set and remove Meta Variable expiry settings on all chatters (see docs below).
 
 ### Expected Keys
 
 Parameter | Description | Optionality
 --- | --- | ---
-`variables` | An array that takes one or more Meta Variable names. Will **not** throw an error if the array is empty. | **needed**
+`variables` | An array. Takes one or more Meta Variable names. Will **not** throw an error if the array is empty. | **needed**
 ### Example Request Body
 ```
 {"variables":


### PR DESCRIPTION
Adds docs for meta variable deletion endpoints:
`https://<bothandle>.ada.support/chatters/<chatter-token>/remove_from_storage` and `https://<bothandle>.ada.support/chatters/<chatter-token>/set_expiry`