### PR TITLE
PER-272: update docs to reflect new default meta vars (formerly header)

### DIFF
--- a/ada-embed.md
+++ b/ada-embed.md
@@ -214,6 +214,16 @@ Used to pass meta information about a Chatter. This can be useful for tracking i
 </script>
 ```
 
+Please keep in mind that the following Chatter meta properties are set for you by default, though you are free to override their values.
+
+Name | Type | Description | Example
+--- | --- | --- | ---
+`browser` | `String` | The end-user's browser type | "chrome", "firefox", "safari", etc.
+`browser_version` | `String` | The end-user's browser version | "76.0.3809.132"
+`device` | `String` | The end-user's device type | "macos"
+`language` | `String` | The language specified by the end-user's browser in ISO 639-1 language format | "en", "fr", "es", etc.
+`user_agent` | `String` | Your end-user's user agent info | "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
+
 
 **Note**: Because unsanitized meta variable names are sanitized by Ada's backend, meta variable names should not include whitespace, emojis, special characters or periods.
 
@@ -312,7 +322,9 @@ adaEmbed.setMetaFields({
   name: "Ada Lovelace"
 });
 ```
-**Note:** Because unsanitized meta variable names are sanitized by Ada's backend, meta variable names should not include whitespace, emojis, special characters or periods. Please consult the table of variable name formats presented in the [metaFields](#metafields-type-object) settings object.
+**Note:** Please keep in mind the following: 1) Because unsanitized meta variable names are sanitized by Ada's backend, meta variable names should not include whitespace, emojis, special characters or periods; 2) Some default meta variables are already set for you.
+
+Please consult the table of variable name formats and the table of default meta variables presented in the [metaFields](#metafields-type-object) settings object.
 
 #### `start(adaSettings)` `@param {Object}`
 Used to add the Ada Embed interface to your page. Takes in an optional object for setting customization.
@@ -358,7 +370,9 @@ Key | Value | Description
 ```
 https://ada-example.ada.support/chat/?language=fr&name=Ada
 ```
-**Note:** Because unsanitized meta variable names are sanitized by Ada's backend, meta variable names should not include whitespace, emojis, special characters or periods. Please consult the table of variable name formats presented in the [metaFields](#metafields-type-object) settings object.
+**Note:** Please keep in mind the following: 1) Because unsanitized meta variable names are sanitized by Ada's backend, meta variable names should not include whitespace, emojis, special characters or periods; 2) Some default meta variables are already set for you.
+
+Please consult the table of variable name formats and the table of default meta variables presented in the [metaFields](#metafields-type-object) settings object.
 
 #### Sample code for iOS (Swift): [Here](https://gist.github.com/brandonmowat/60154e81744f48866d2a1fba021f89a2)
 

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -10,9 +10,9 @@
 ## **Prerequisites**
 This document is intended *for developers* with working knowledge of REST APIs and JavaScript. It is assumed that you have write-access to your company's code repository which contains **Ada Embed**.
 
-The following instructions will reference the usage of a **chatter token**. See the [Ada EmbedScript docs](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#configuring-your-bot) for more information on how to get a chatter's token using ```chatterTokenCallback```.
+The following instructions will reference the usage of a **chatter token**. See the [Ada Embed docs](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#configuring-your-bot) for more information on how to get a chatter's token using ```chatterTokenCallback```.
 
-The following instructions also abide by the assumption that any meta variable (aka meta property) you have previously passed to Ada via EmbedScript - whether by [query paramaters](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#faq), the [setMetaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#setmetafieldsmetafields-param-object) action or the [metaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#metafields-type-object) settings object - only consist of sanitized names.
+The following instructions also abide by the assumption that any meta variable (aka meta property) you have previously passed to Ada via Embed - whether by [query paramaters](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#faq), the [setMetaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#setmetafieldsmetafields-param-object) action or the [metaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#metafields-type-object) settings object - only consist of sanitized names.
 
 Because unsanitized meta variable names are sanitized by Ada's backend, searching for - and removing - unsanitized variables using the endpoints described below will not be possible (and may result in unexpected issues).
 

--- a/api/metavariables.md
+++ b/api/metavariables.md
@@ -1,6 +1,6 @@
 # Meta Variable Deletion - Developer Docs
 
-> Meta Variables are automatically collected and specific to an individual chatter, as part of the implementation of your **Ada** bot. Any information passed from **your database** to the bot as metadata will be stored by Ada as a Meta Variable of that chatter. However, Ada provides two API endpoints and runs a nightly task, all of which work together to ensure that given Meta Variables are deleted from a given chatter.
+> Meta Variables are automatically collected and specific to an individual chatter, as part of the implementation of your **Ada** bot. Any information passed from **your database** to the bot as metadata will be stored by Ada as a Meta Variable of that chatter. However, Ada provides two API endpoints and runs a nightly task, all of which work together to ensure that given Meta Variables are deleted from a given chatter if you so choose.
 
 ![ada animated gif](https://user-images.githubusercontent.com/4740147/47372740-5b5dca80-d6b8-11e8-87e7-1b76d48370d8.gif "Ada Animated Gif")
 
@@ -12,7 +12,7 @@ This document is intended *for developers* with working knowledge of REST APIs a
 
 The following instructions will reference the usage of a **chatter token**. See the [Ada EmbedScript docs](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#configuring-your-bot) for more information on how to get a chatter's token using ```chatterTokenCallback```.
 
-The following instructions also abide by the assumption that any meta variable you have previously passed to Ada via EmbedScript - whether by [query paramaters](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#faq), the [setMetaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#setmetafieldsmetafields-param-object) action or the [metaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#metafields-type-object) settings object - only consist of sanitized names.
+The following instructions also abide by the assumption that any meta variable (aka meta property) you have previously passed to Ada via EmbedScript - whether by [query paramaters](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#faq), the [setMetaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#setmetafieldsmetafields-param-object) action or the [metaFields](https://github.com/AdaSupport/docs/blob/master/ada-embed.md#metafields-type-object) settings object - only consist of sanitized names.
 
 Because unsanitized meta variable names are sanitized by Ada's backend, searching for - and removing - unsanitized variables using the endpoints described below will not be possible (and may result in unexpected issues).
 

--- a/chaperone.md
+++ b/chaperone.md
@@ -284,3 +284,5 @@ In the (near) future we intend to release a versionless Chaperone embed script. 
 
 ## Questions
 Need some help? Get in touch with us at [help@ada.support](mailto:help@ada.support).
+
+dlfd

--- a/chaperone.md
+++ b/chaperone.md
@@ -203,13 +203,23 @@ Can be used to programatically close the Web Chat view. This method cannot be us
 
 
 #### `setMetaField(fieldName, value)` `@param {String}` `@param {String}`
-You can use this method to set meta properties for the Chatter. This can be useful for tracking information about your end users, as well as for personalizing their experience. For example, you may wish to track the `email` and `name` for conversation attribution. Once set, this information can be accessed in the email attachment from Handoff Form submissions, or via the Chatter modal in the **Conversations** page of your Ada dashboard. Additionally, the bot can be configured to call the user by name. You can learn more about personalization [here](https://adasupporthelp.zendesk.com/hc/en-us/articles/360018562373-Personalization).
+You can use this method to set meta properties (aka meta variables) for the Chatter. This can be useful for tracking information about your end users, as well as for personalizing their experience. For example, you may wish to track the `email` and `name` for conversation attribution. Once set, this information can be accessed in the email attachment from Handoff Form submissions, or via the Chatter modal in the **Conversations** page of your Ada dashboard. Additionally, the bot can be configured to call the user by name. You can learn more about personalization [here](https://adasupporthelp.zendesk.com/hc/en-us/articles/360018562373-Personalization).
 
 **Example:**
 ```javascript
 adaBot.setMetaField('email', 'joe-schmoe123@gmail.com');
 adaBot.setMetaField('name', 'Joe Schmoe');
 ```
+
+Please note that the following Chatter meta properties are set for you by default, so please refrain from using their names as a `fieldName` for other meta properties:
+Name | Type | Description | Example
+--- | --- | --- | ---
+`browser` | `String` | The end-user's browser type | "chrome", "firefox", "safari", etc.
+`browser_version` | `String` | The end-user's browser version | "76.0.3809.132"
+`device` | `String` | The end-user's device type | "macos"
+`language` | `String` | The language specified by the end-user's browser in ISO 2 letter language code | "en", "fr", "es", etc.
+`user_agent` | `String` | Your end-user's user agent info | "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
+
 
 #### `show()`
 Can be used to programatically open the Web Chat view. This is useful if you would like to open the Web Chat automatically when the page loads, or when clicking a custom button.

--- a/chaperone.md
+++ b/chaperone.md
@@ -166,6 +166,7 @@ Takes in a language code to programatically set the bot language. Languages must
   });
 </script>
 ```
+`Language` is also set for you by default as a meta field (see `setMetaField` for more details).
 
 #### `mobileOverlay` `@type {Boolean}`
 By default, the Web Chat will open in a new window on mobile devices. If you'd prefer to have it open as an overlay overtop the current window, set this option to `true`.
@@ -211,13 +212,14 @@ adaBot.setMetaField('email', 'joe-schmoe123@gmail.com');
 adaBot.setMetaField('name', 'Joe Schmoe');
 ```
 
-Please note that the following Chatter meta properties are set for you by default, so please refrain from using their names as a `fieldName` for other meta properties:
+Please note that the following Chatter meta properties are set for you by default, though you are free to override their values.
+
 Name | Type | Description | Example
 --- | --- | --- | ---
 `browser` | `String` | The end-user's browser type | "chrome", "firefox", "safari", etc.
 `browser_version` | `String` | The end-user's browser version | "76.0.3809.132"
 `device` | `String` | The end-user's device type | "macos"
-`language` | `String` | The language specified by the end-user's browser in ISO 2 letter language code | "en", "fr", "es", etc.
+`language` | `String` | The language specified by the end-user's browser in ISO 639-1 language format | "en", "fr", "es", etc.
 `user_agent` | `String` | Your end-user's user agent info | "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
 
 
@@ -250,9 +252,19 @@ See the table below for a list of available parameters.
 Key | Value | Type | Description
 --- | --- | --- | ---
 `greeting` | The greeting Answer ID | Query String | Specify a custom greeting
-`language` | A supported ISO 639-1 language | Query String | Set the Web Chat language
-`*` | Any other key is treated as a meta field | Query String | Used to pass meta informaton about an end user
+`language`<sup>1</sup> | A supported ISO 639-1 language | Query String | Set the Web Chat language
+`*` | Any other key is treated as a meta field<sup>2</sup> | Query String | Used to pass meta informaton about an end user
 `private` | `true` or 1 | Query String | Used to forget the Chat session on refresh.
+
+<sup>2</sup> Please keep in mind that the following meta fields are set for you by default, though you are free to override their values.
+
+Name | Type | Description | Example
+--- | --- | --- | ---
+`browser` | `String` | The end-user's browser type | "chrome", "firefox", "safari", etc.
+`browser_version` | `String` | The end-user's browser version | "76.0.3809.132"
+`device` | `String` | The end-user's device type | "macos"
+<sup>1</sup>`language` | `String` | The language specified by the end-user's browser in ISO 639-1 language format | "en", "fr", "es", etc.
+`user_agent` | `String` | Your end-user's user agent info | "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
 
 #### Q: How do I customize the look of the Ada Chat button?
 **A:** There are many ways to do this, and ultimately this will be up to your team's developers. That being said, we recommend targetting the `button.ada-chat-button` element in your CSS and overriding existing styles.

--- a/chaperone.md
+++ b/chaperone.md
@@ -284,5 +284,3 @@ In the (near) future we intend to release a versionless Chaperone embed script. 
 
 ## Questions
 Need some help? Get in touch with us at [help@ada.support](mailto:help@ada.support).
-
-dlfd

--- a/chaperone.md
+++ b/chaperone.md
@@ -252,19 +252,9 @@ See the table below for a list of available parameters.
 Key | Value | Type | Description
 --- | --- | --- | ---
 `greeting` | The greeting Answer ID | Query String | Specify a custom greeting
-`language`<sup>1</sup> | A supported ISO 639-1 language | Query String | Set the Web Chat language
-`*` | Any other key is treated as a meta field<sup>2</sup> | Query String | Used to pass meta informaton about an end user
+`language` | A supported ISO 639-1 language | Query String | Set the Web Chat language
+`*` | Any other key is treated as a meta field | Query String | Used to pass meta informaton about an end user
 `private` | `true` or 1 | Query String | Used to forget the Chat session on refresh.
-
-<sup>2</sup> Please keep in mind that the following meta fields are set for you by default, though you are free to override their values.
-
-Name | Type | Description | Example
---- | --- | --- | ---
-`browser` | `String` | The end-user's browser type | "chrome", "firefox", "safari", etc.
-`browser_version` | `String` | The end-user's browser version | "76.0.3809.132"
-`device` | `String` | The end-user's device type | "macos"
-<sup>1</sup>`language` | `String` | The language specified by the end-user's browser in ISO 639-1 language format | "en", "fr", "es", etc.
-`user_agent` | `String` | Your end-user's user agent info | "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
 
 #### Q: How do I customize the look of the Ada Chat button?
 **A:** There are many ways to do this, and ultimately this will be up to your team's developers. That being said, we recommend targetting the `button.ada-chat-button` element in your CSS and overriding existing styles.


### PR DESCRIPTION
Tracking info was formerly saved as header vars. We will soon be changing that so they are saved as meta vars instead. As such, we need to update the docs so users know that there will be a certain set of default meta vars.