### PR TITLE
SUP-377: Updating Docs to show Android Error Handling

### DIFF
--- a/ada-android-sdk.md
+++ b/ada-android-sdk.md
@@ -353,9 +353,9 @@ adaDialog.reset()
 ```
 
 ## Error Handling
-If the Webview fails to load within the timeout period (default is 30000 milliseconds) you may want to handle this as an error. 
+If the `WebView` fails to load within the timeout period (default is 30000 milliseconds) you may want to handle this as an error. 
 To do this you can set `webViewLoadingErrorCallback` by passing the callback to `AdaEmbedView` using a lambda expression to set the property. 
-This function will be called if there was an error loading the webview or if it didn't finish loading in the specified timeout period.
+This function will be called if there was an error loading the `WebView` or if it didn't finish loading in the specified timeout period.
 
 **Example:**
 ```kotlin

--- a/ada-android-sdk.md
+++ b/ada-android-sdk.md
@@ -236,7 +236,8 @@ app:ada_accept_third_party_cookies = "true"
 
 #### Auth Token Callback
 The SDK allows you to periodically pass JWT tokens.
-To do this you need to setup `zdChatterAuthCallback` to `AdaEmbedView`.
+To do this you need to setup `zdChatterAuthCallback` by passing the callback 
+to `AdaEmbedView` using a lambda expression to set the property. 
 If SDK requests JWT token this callback will be fired.
 ```kotlin
 adaView.zdChatterAuthCallback = {
@@ -353,8 +354,8 @@ adaDialog.reset()
 
 ## Error Handling
 If the Webview fails to load within the timeout period (default is 30000 milliseconds) you may want to handle this as an error. 
-You can set this up by setting `webViewLoadingErrorCallback` to `AdaEmbedView`. This function will be called if there
-was an error loading the webview or if it didn't finish loading in the specified timeout period.
+To do this you can set `webViewLoadingErrorCallback` by passing the callback to `AdaEmbedView` using a lambda expression to set the property. 
+This function will be called if there was an error loading the webview or if it didn't finish loading in the specified timeout period.
 
 **Example:**
 ```kotlin

--- a/ada-android-sdk.md
+++ b/ada-android-sdk.md
@@ -352,7 +352,7 @@ adaDialog.reset()
 ```
 
 ## Error Handling
-If the Webview fails to load within time (default is 30000 milliseconds) you may want to handle the error. 
+If the Webview fails to load within the timeout period (default is 30000 milliseconds) you may want to handle this as an error. 
 You can set this up by setting `webViewLoadingErrorCallback` to `AdaEmbedView`. This function will be called if there
 was an error loading the webview or if it didn't finish loading in the specified timeout period.
 
@@ -392,7 +392,6 @@ Or as a setting as part of the AdaEmbedView Builder
 
 ## Questions
 Need some help? Get in touch with us at [help@ada.support](mailto:help@ada.support).
-
 
 
 

--- a/ada-android-sdk.md
+++ b/ada-android-sdk.md
@@ -52,10 +52,10 @@ allprojects {
 Next, add the dependency to the application level `build.gradle`:
 ```groovy
 //  if your project has artifacts within the androidx namespace
-implementation 'support.ada.embed:android-sdk-appcompat:1.3.1'
+implementation 'support.ada.embed:android-sdk-appcompat:1.3.3'
 
 //  if your project uses Android Support Library
-implementation 'support.ada.embed:android-sdk-appcompat-legacy:1.3.1'
+implementation 'support.ada.embed:android-sdk-appcompat-legacy:1.3.3'
 ```
 
 ## Chat Frame Creation 
@@ -293,6 +293,7 @@ val adaSettings = AdaEmbedView.Settings.Builder("ada-example")
     .language("en")
     .metaFields(metaFieldsMap)
     .acceptThirdPartyCookies(true)
+    .loadTimeoutMillis(30000)
     .build()
 ```
 ## Actions
@@ -348,6 +349,45 @@ val adaDialog = supportFragmentManager.findFragmentByTag(AdaEmbedDialog.TAG) as 
 adaDialog.setMetaFields(metaFields)
 adaDialog.deleteHistory()
 adaDialog.reset()
+```
+
+## Error Handling
+If the Webview fails to load within time (default is 30000 milliseconds) you may want to handle the error. 
+You can set this up by setting `webViewLoadingErrorCallback` to `AdaEmbedView`. This function will be called if there
+was an error loading the webview or if it didn't finish loading in the specified timeout period.
+
+**Example:**
+```kotlin
+private fun logWebViewLoadError() {
+    // Write any logic for the WebView not loading here
+    Log.d("Webview Error", "Error Loading Webview")
+}
+
+adaView.webViewLoadingErrorCallback = { logWebViewLoadError() }
+```
+
+If you want to adjust the timeout length to trigger an error you can either specify this in your XML settings with the `app:ada_load_timeout` attribute:
+```xml
+<support.ada.embed.widget.AdaEmbedView
+            android:id="@+id/xml_ada_view"
+            android:layout_width="0dp"
+            android:layout_height="400dp"
+            app:ada_handle="@string/ada_handle_res"
+            app:ada_load_timeout="30000"
+            app:ada_language="en"
+            app:ada_metaFields="@raw/metafields"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+```
+
+Or as a setting as part of the AdaEmbedView Builder
+```kotlin
+        AdaEmbedView.Settings.Builder("ada-example")
+                .language("en")
+                .loadTimeoutMillis(20000)
+                .build()
+
 ```
 
 ## Questions

--- a/ada-android-sdk.md
+++ b/ada-android-sdk.md
@@ -381,7 +381,7 @@ If you want to adjust the timeout length to trigger an error you can either spec
             app:layout_constraintTop_toTopOf="parent" />
 ```
 
-Or as a setting as part of the AdaEmbedView Builder
+Or as part of the AdaEmbedView builder
 ```kotlin
         AdaEmbedView.Settings.Builder("ada-example")
                 .language("en")
@@ -392,7 +392,6 @@ Or as a setting as part of the AdaEmbedView Builder
 
 ## Questions
 Need some help? Get in touch with us at [help@ada.support](mailto:help@ada.support).
-
 
 
 

--- a/ada-ios-sdk.md
+++ b/ada-ios-sdk.md
@@ -20,7 +20,7 @@ This document is intended for bot specialists and developers with working knowle
 The Ada iOS SDK can be installed manually or using CocoaPods. The SDK supports iOS 10.x and up.
 
 ### Option 1: Manual Integration
-1. Download the Ada iOS SDK framework [here](https://github.com/AdaSupport/ios-sdk/releases/download/1.3.2/AdaEmbedFramework.framework.zip).
+1. Download the Ada iOS SDK framework [here](https://github.com/AdaSupport/ios-sdk/releases/download/1.1.1/AdaEmbedFramework.framework.zip).
 2. Right click on the project file in XCode, then click "Add Files to *MyProjectName*". Ensure that the *Copy groups* option is selected.
 3. Ensure your Deployment Target is set to 10.0, which is the minimum iOS version that the Ada iOS SDK is compatible with.
 4. In the project settings under General, link the `AdaEmbedFramework.framework` under the Embedded Binaries section. You can do this by dragging the framework from the left side list in the Embedded Binaries list.

--- a/ada-ios-sdk.md
+++ b/ada-ios-sdk.md
@@ -20,7 +20,7 @@ This document is intended for bot specialists and developers with working knowle
 The Ada iOS SDK can be installed manually or using CocoaPods. The SDK supports iOS 10.x and up.
 
 ### Option 1: Manual Integration
-1. Download the Ada iOS SDK framework [here](https://github.com/AdaSupport/ios-sdk/releases/download/1.1.1/AdaEmbedFramework.framework.zip).
+1. Download the Ada iOS SDK framework [here](https://github.com/AdaSupport/ios-sdk/releases/download/1.3.2/AdaEmbedFramework.framework.zip).
 2. Right click on the project file in XCode, then click "Add Files to *MyProjectName*". Ensure that the *Copy groups* option is selected.
 3. Ensure your Deployment Target is set to 10.0, which is the minimum iOS version that the Ada iOS SDK is compatible with.
 4. In the project settings under General, link the `AdaEmbedFramework.framework` under the Embedded Binaries section. You can do this by dragging the framework from the left side list in the Embedded Binaries list.


### PR DESCRIPTION
This update is to provide clients instructions on how to use the error handling and timeout feature that was recently added to the AndroidSDK.